### PR TITLE
Fix docker-compose portforwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: owncloud/server:${OWNCLOUD_VERSION}
     restart: always
     ports:
-      - ${HTTP_PORT}:8080
+      - ${HTTP_PORT}:80
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Before this change:

```
# docker-compose ps
          Name                         Command                       State                            Ports                 
----------------------------------------------------------------------------------------------------------------------------
owncloudserver_db_1         /usr/bin/entrypoint /bin/s ...   Up (health: starting)   3306/tcp                               
owncloudserver_owncloud_1   /usr/bin/entrypoint /usr/b ...   Up (health: starting)   443/tcp, 80/tcp, 0.0.0.0:8080->8080/tcp
owncloudserver_redis_1      /usr/bin/entrypoint /bin/s ...   Up (health: starting)   6379/tcp                               
# curl 0.0.0.0:8080
curl: (56) Recv failure: Connection reset by peer
#
```

after this change:

```
# docker-compose ps
          Name                         Command                  State                   Ports            
---------------------------------------------------------------------------------------------------------
owncloudserver_db_1         /usr/bin/entrypoint /bin/s ...   Up (healthy)   3306/tcp                     
owncloudserver_owncloud_1   /usr/bin/entrypoint /usr/b ...   Up (healthy)   443/tcp, 0.0.0.0:8080->80/tcp
owncloudserver_redis_1      /usr/bin/entrypoint /bin/s ...   Up (healthy)   6379/tcp                     
# curl 0.0.0.0:8080
# 
```