### PR TITLE
Fixed typo in Commandline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can run `occ` commands inside the ownCloud docker image, without caring for 
 occ user:report
 ```
 
-You can also run commands via `docker exec`, or `docker-compse exec`:
+You can also run commands via `docker exec`, or `docker-compose exec`:
 
 ```
 docker exec -ti example_owncloud_1 occ user:report


### PR DESCRIPTION
Changed "docker-compse" to "docker-compose".