### PR TITLE
fix CI for latest version

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -8,6 +8,7 @@ def main(ctx):
       'ldap': 'https://marketplace.owncloud.com/api/v1/apps/user_ldap/0.14.0',
       'ldap_sha': 'f6bc61e2820b464cf7ad08061607f45ede892f0257d7c5ac1aa5a969caa58769',
       'php': '7.3',
+      'behat_version': '10.3.2',
       'base': 'v19.10',
       'tags': [],
     },
@@ -664,7 +665,7 @@ def api(config):
     'pull': 'always',
     'commands': [
       'mkdir -p vendor-bin/behat',
-      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']['value']),
+      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']),
       'cd vendor-bin/behat/ && composer install',
     ],
   },
@@ -719,7 +720,7 @@ def ui(config):
     'pull': 'always',
     'commands': [
       'mkdir -p vendor-bin/behat',
-      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']['value']),
+      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']),
       'cd vendor-bin/behat/ && composer install',
     ],
   },
@@ -798,7 +799,8 @@ def cleanup(config):
   }]
 
 def versionize(version):
-    if version == 'latest':
-        return 'master'
-    else:
-        return 'v%s' % (version.replace("rc", "RC").replace("-", ""))
+  if 'behat_version' in version:
+    raw_version = version['behat_version']
+  else:
+    raw_version = version['value']
+  return 'v%s' % (raw_version.replace("rc", "RC").replace("-", ""))


### PR DESCRIPTION
## Problem
- `latest` version was using the wrong behat suite dependencies.

## Solution
- add an optional `behat_version` key to the versions dict.

If this works here, we need to copy the solution to enterprise and appliance repo.