### PR TITLE
release 10.5.0RC3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,12 +2,12 @@ def main(ctx):
   versions = [
 
     {
-      'value': '10.5.0-rc2',
-      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200624-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200624.tar.bz2',
-      'tarball_sha': '8d0e429497c0187866d625ad6e78041707b06645bace737c86851e35746f383d',
-      'ldap': 'https://marketplace.owncloud.com/api/v1/apps/user_ldap/0.15.1',
-      'ldap_sha': '1e34bb56850ac93c8625809247a6d7b23113eda53c456c7560dda1f58f42ab93',
+      'value': '10.5.0-rc3',
+      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629-qa.tar.bz2',
+      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629.tar.bz2',
+      'tarball_sha': '3f9494ea5c1e8eeb3046f105c0a7cb69a4697b2e6ea8381fe5f2f249a4921212',
+      'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2RC1/user_ldap-0.15.2RC1.tar.gz',
+      'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',
       'base': 'v20.04',
       'tags': ['10.5'],

--- a/.drone.star
+++ b/.drone.star
@@ -754,6 +754,7 @@ def ui(config):
       'LOCAL_MAILHOG_HOST': 'email',
     },
     'commands': [
+      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=config:system:set --type boolean --value false grace_period.demo_key.show_popup"',
       'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config['step'], config['split']),
     ],
   }]

--- a/.drone.star
+++ b/.drone.star
@@ -4,8 +4,8 @@ def main(ctx):
     {
       'value': '10.5.0-rc3',
       'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629.tar.bz2',
-      'tarball_sha': '3f9494ea5c1e8eeb3046f105c0a7cb69a4697b2e6ea8381fe5f2f249a4921212',
+      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200630.tar.bz2',
+      'tarball_sha': 'b155a8001cb2bd7262e63a1a38e8704fe415a17bb4ee39f08ef46205d145be0f',
       'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2RC1/user_ldap-0.15.2RC1.tar.gz',
       'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',

--- a/.drone.star
+++ b/.drone.star
@@ -48,7 +48,7 @@ def main(ctx):
   config = {
     'version': None,
     'arch': None,
-    'split': 4,
+    'split': 5,
     'downstream': [
 
     ],

--- a/.drone.star
+++ b/.drone.star
@@ -754,6 +754,7 @@ def ui(config):
       'LOCAL_MAILHOG_HOST': 'email',
     },
     'commands': [
+      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=app:disable theme-enterprise"',
       'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=config:system:set --type boolean --value false grace_period.demo_key.show_popup"',
       'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config['step'], config['split']),
     ],

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -11,8 +11,7 @@ EXPOSE 8080
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["/usr/bin/owncloud", "server"]
 
-# allow-insecure, as we have registered a sernet repo in the php base image with an expired key
-RUN apt-get --allow-insecure-repositories update -y && \
+RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Prepare docker for 10.3.0RC3

Note: This is the first time I am messing with the 'ldap' key in the drone.star data structure. Historically the value there is a URL at the marketplace pointing to a direct download of the latest user_ldap app tar.gz
Now as we are updating this app itself now for the first time, I am redirecting that url to the unreleased user_ldap-0.52RC1.tar.gz on github.

I do that to avoid any inconsistencies. The user ldap app is also included in the 'tarball' with exactly this versions.
Not sure, if the entry in drone.star is meant as an override, or as something different. In my opinion, it just should not be there. It is undocumented, redundant, and a potential source of error.

If anybody knows why it is there in the first place, please add a comment.