### PR TITLE
Release 10.5.0 rc4

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,12 +2,12 @@ def main(ctx):
   versions = [
 
     {
-      'value': '10.5.0-rc2',
-      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200624-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200624.tar.bz2',
-      'tarball_sha': '8d0e429497c0187866d625ad6e78041707b06645bace737c86851e35746f383d',
-      'ldap': 'https://marketplace.owncloud.com/api/v1/apps/user_ldap/0.15.1',
-      'ldap_sha': '1e34bb56850ac93c8625809247a6d7b23113eda53c456c7560dda1f58f42ab93',
+      'value': '10.5.0-rc3',
+      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629-qa.tar.bz2',
+      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629.tar.bz2',
+      'tarball_sha': '3f9494ea5c1e8eeb3046f105c0a7cb69a4697b2e6ea8381fe5f2f249a4921212',
+      'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2RC1/user_ldap-0.15.2RC1.tar.gz',
+      'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',
       'base': 'v20.04',
       'tags': ['10.5'],

--- a/.drone.star
+++ b/.drone.star
@@ -754,6 +754,7 @@ def ui(config):
       'LOCAL_MAILHOG_HOST': 'email',
     },
     'commands': [
+      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=config:system:set --type boolean --value false grace_period.demo_key.show_popup"',
       'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config['step'], config['split']),
     ],
   }]

--- a/.drone.star
+++ b/.drone.star
@@ -2,11 +2,11 @@ def main(ctx):
   versions = [
 
     {
-      'value': '10.5.0-rc3',
-      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200630.tar.bz2',
-      'tarball_sha': 'b155a8001cb2bd7262e63a1a38e8704fe415a17bb4ee39f08ef46205d145be0f',
-      'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2RC1/user_ldap-0.15.2RC1.tar.gz',
+      'value': '10.5.0-rc4',
+      'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200710-qa.tar.bz2',
+      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200710.tar.bz2',
+      'tarball_sha': 'd57af4142e621d9e3dd0ee36aa52f98426deb0eb2153d3b08646aa303ee32931',
+      'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2/user_ldap-0.15.2.tar.gz',
       'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',
       'base': 'v20.04',

--- a/.drone.star
+++ b/.drone.star
@@ -4,8 +4,8 @@ def main(ctx):
     {
       'value': '10.5.0-rc3',
       'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200629.tar.bz2',
-      'tarball_sha': '3f9494ea5c1e8eeb3046f105c0a7cb69a4697b2e6ea8381fe5f2f249a4921212',
+      'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200630.tar.bz2',
+      'tarball_sha': 'b155a8001cb2bd7262e63a1a38e8704fe415a17bb4ee39f08ef46205d145be0f',
       'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2RC1/user_ldap-0.15.2RC1.tar.gz',
       'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',

--- a/.drone.star
+++ b/.drone.star
@@ -48,7 +48,7 @@ def main(ctx):
   config = {
     'version': None,
     'arch': None,
-    'split': 4,
+    'split': 5,
     'downstream': [
 
     ],

--- a/.drone.star
+++ b/.drone.star
@@ -638,7 +638,7 @@ def wait(config):
     'image': 'owncloud/ubuntu:latest',
     'pull': 'always',
     'commands': [
-      'wait-for-it -t 600 server:8080',
+      'wait-for-it -t 1200 server:8080',
     ],
   }]
 

--- a/.drone.star
+++ b/.drone.star
@@ -754,8 +754,6 @@ def ui(config):
       'LOCAL_MAILHOG_HOST': 'email',
     },
     'commands': [
-      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=app:disable theme-enterprise"',
-      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=config:system:set --type boolean --value false grace_period.demo_key.show_popup"',
       'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config['step'], config['split']),
     ],
   }]

--- a/.drone.star
+++ b/.drone.star
@@ -754,6 +754,7 @@ def ui(config):
       'LOCAL_MAILHOG_HOST': 'email',
     },
     'commands': [
+      'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=app:disable theme-enterprise"',
       'curl -k -s -u admin:admin http://server:8080/ocs/v2.php/apps/testing/api/v1/occ -d "command=config:system:set --type boolean --value false grace_period.demo_key.show_popup"',
       'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config['step'], config['split']),
     ],

--- a/.drone.star
+++ b/.drone.star
@@ -638,7 +638,7 @@ def wait(config):
     'image': 'owncloud/ubuntu:latest',
     'pull': 'always',
     'commands': [
-      'wait-for-it -t 1200 server:8080',
+      'wait-for-it -t 600 server:8080',
     ],
   }]
 

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -11,8 +11,7 @@ EXPOSE 8080
 ENTRYPOINT ["/usr/bin/entrypoint"]
 CMD ["/usr/bin/owncloud", "server"]
 
-# allow-insecure, as we have registered a sernet repo in the php base image with an expired key
-RUN apt-get --allow-insecure-repositories update -y && \
+RUN apt-get update -y && \
   apt-get upgrade -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Docker update using owncloud-complete-20200710.tar.bz2with apps updated since RC3:

files_mediaviewer-1.0.3RC2, market-0.6.0RC2, user_ldap-0.15.2, notifications-0.5.0 (sorry), oauth2-0.4.3 (sorry), windows_network_drive-1.1.0,
sharepoint-0.4.0, user_shibboleth-3.5.0, enterprise_key-0.2.1, wopi-1.4.0, files_ldap_home-0.5.0, firewall-2.10.1, admin_audit-2.1.1, workflow-0.5.1,
theme-enterprise-2.2.1, systemtags_management-0.4.1, twofactor_totp-0.7.0, files_classifier-1.3.0

Most (all?) enterprise apps remain disabled after installation. Admins should be notified about this new (but required) behaviour.

notifications and oauth2 fall back to their previous versions. The issue with notifications is still not fixed int 0.5.1 and oauth2 updates for 0.4.4 are p4-low and we do not have a test setup yet. We cannot block this p2 with that.

