### PR TITLE
Fix typo in changelog

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,7 +5,7 @@ def main(ctx):
       'value': '10.5.0-rc7',
       'qa': 'https://download.owncloud.org/community/testing/owncloud-complete-20200728-qa.tar.bz2',
       'tarball': 'https://download.owncloud.org/community/testing/owncloud-complete-20200728.tar.bz2',
-      'tarball_sha': '93e5fabec797bad944f97efc67d767036ae331a4e116b56d69ddaa662ae2a1aa',
+      'tarball_sha': 'f98b1292bcc6e742ba42370705c1d3713e9611f46d89d97f54bd072472b4f243',
       'ldap': 'https://github.com/owncloud/user_ldap/releases/download/v0.15.2/user_ldap-0.15.2.tar.gz',
       'ldap_sha': '2c4cdd4f08c7b9541761afddf9ac33210619fc21c62463b0834dc651e12ecf87',
       'php': '7.4',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## 2019-07-29
 
 * Added
-  * Link to docuemntation for installation
+  * Link to documentation for installation
 * Removed
   * Drop docker and docker-compose examples
 


### PR DESCRIPTION
And update the tarball_sha of the rebuilt owncloud-complete-20200728.tar.bz2

This will cause a rebuild of the 10.5.0RC7 image, which we want to happen.