### PR TITLE
fix: fix htaccess permissions for non-root users

### DIFF
--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -22,4 +22,4 @@ COPY ./overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -22,4 +22,4 @@ COPY ./overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -22,4 +22,4 @@ COPY ./overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess


### PR DESCRIPTION
Fixes: https://github.com/owncloud-docker/server/issues/213

Platforms that uses arbitrary UID's can't update `.htaccess` files during startup due to permission issues.
