### PR TITLE
[tests-only] Split API smoke tests into 10 pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -33,7 +33,8 @@ def main(ctx):
     config = {
         "version": None,
         "arch": None,
-        "split": 5,
+        "splitAPI": 8,
+        "splitUI": 5,
         "description": "ownCloud - Secure Collaboration Platform",
         "repo": ctx.repo.name,
     }
@@ -148,7 +149,7 @@ def docker(config):
     test = []
 
     if config["arch"] == "amd64":
-        for step in list(range(1, config["split"] + 1)):
+        for step in list(range(1, config["splitAPI"] + 1)):
             config["step"] = step
 
             test.append({
@@ -209,7 +210,7 @@ def docker(config):
                 },
             })
 
-        for step in list(range(1, config["split"] + 1)):
+        for step in list(range(1, config["splitUI"] + 1)):
             config["step"] = step
 
             test.append({
@@ -644,7 +645,7 @@ def api(config):
                 "SKELETON_DIR": "/mnt/data/apps/testing/data/apiSkeleton",
             },
             "commands": [
-                'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type api --part %d %d' % (config["step"], config["split"]),
+                'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type api --part %d %d' % (config["step"], config["splitAPI"]),
             ],
         },
     ]
@@ -707,7 +708,7 @@ def ui(config):
                 "LOCAL_MAILHOG_HOST": "email",
             },
             "commands": [
-                'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config["step"], config["split"]),
+                'bash tests/acceptance/run.sh --remote --tags "@smokeTest&&~@skip&&~@skipOnDockerContainerTesting" --type webUI --part %d %d' % (config["step"], config["splitUI"]),
             ],
         },
     ]

--- a/.drone.star
+++ b/.drone.star
@@ -33,7 +33,7 @@ def main(ctx):
     config = {
         "version": None,
         "arch": None,
-        "splitAPI": 8,
+        "splitAPI": 10,
         "splitUI": 5,
         "description": "ownCloud - Secure Collaboration Platform",
         "repo": ctx.repo.name,


### PR DESCRIPTION
A recent CI run has:
```
10.7.0
pipe min scenarios
api1  38 runsh: Total 110 scenarios (110 passed, 0 failed)
api2  41 runsh: Total 125 scenarios (125 passed, 0 failed)
api3  29 runsh: Total 68 scenarios (68 passed, 0 failed)
api4  54 runsh: Total 178 scenarios (178 passed, 0 failed)
api5  17 runsh: Total 59 scenarios (59 passed, 0 failed)

10.6.0
pipe min scenarios
api1  29 runsh: Total 83 scenarios (83 passed, 0 failed)
api2  43 runsh: Total 131 scenarios (131 passed, 0 failed)
api3  38 runsh: Total 95 scenarios (95 passed, 0 failed)
api4  23 runsh: Total 52 scenarios (52 passed, 0 failed)
api5  65 runsh: Total 185 scenarios (185 passed, 0 failed)
```

In "recent" times we added test scenarios that test the sharing features, with `shared_folder` set to `Shares`, so that has added quite a lot more scenarios., including scenarios tagged `smoketest`. We need to review the `smokeTest` tagging in core - that can be done next week.

When the tests are split into "part 1 of x", "part 2 of x" etc, the logic only looks at the folders of tests (suites) and splits them up into equal numbers of suites in each part. It does not try to pre-examine the number of scenarios in each suite, or the nunber of `smokeTest` scenarios that would be selected. So the run-times of each part can vary a lot, depending on if there happen to be a lot, or only a few, `smokeTest` scenarios in the seelected group of test suites.

I have split the API tests into 10 parts (instead of 5). Let's see if that happens to balance out with some reasonable run times.