### PR TITLE
add a way to run the app instantly?

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ ownCloud is an open-source file sync, share and content collaboration software t
   [owncloud/ubuntu](https://github.com/owncloud-docker/ubuntu#environment-variables),
   [owncloud/php](https://github.com/owncloud-docker/php#environment-variables),
   [owncloud/base](https://github.com/owncloud-docker/base#environment-variables)
+  
+- **Or Run without installation:**\
+  [![TeamCode try-it-now](https://static01.teamcode.com/badge/teamcode-badge-run-in-cloud-en.svg)](https://www.teamcode.com/tin/clone?applicationId=275687444676419584)
 
 ## Docker Tags and respective Dockerfile links
 


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for this app, which help users to quickly run and try the app without installing and configuring the environment. Users don't need to pay for this service. Hope it can help you better promote the app!

[![TeamCode try-it-now](https://static01.teamcode.com/badge/teamcode-badge-run-in-cloud-en.svg)](https://www.teamcode.com/tin/clone?applicationId=275687444676419584)
Guidance: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：(use admin/admin as username/password to log in)

Users click the badge Run in Cloud.
Sign up first if they have not logged in.
After that, they will be directed to the Clone page and start to build & run this app.