### PR TITLE
update to 10.9.1 final

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,13 +1,13 @@
 def main(ctx):
     versions = [
         {
-            "value": "10.9.1-rc2",
-            "qa": "https://download.owncloud.org/community/testing/owncloud-complete-20220111-qa.tar.bz2",
-            "tarball": "https://download.owncloud.org/community/testing/owncloud-complete-20220111.tar.bz2",
-            "tarball_sha": "bc6b155f1995fbbdb85aabc59e83810f01e6cce662a1d91fbfef50014686df72",
+            "value": "10.9.1",
+            "qa": "https://download.owncloud.org/community/testing/owncloud-complete-20220112-qa.tar.bz2",
+            "tarball": "https://download.owncloud.org/community/stable/owncloud-complete-20220112.tar.bz2",
+            "tarball_sha": "3ab3478aee75d6aa6c47db2bc8749a108917df633f2cfab7e8ff67973c2f6147",
             "php": "7.4",
             "base": "v20.04",
-            "tags": [],
+            "tags": ["10.9", "10", "latest"],
         },
         {
             "value": "10.9.0",
@@ -16,7 +16,7 @@ def main(ctx):
             "tarball_sha": "33f0f779f42bd6fcbe3ca117d65a1504a85615e1aa682fa1ebdd51f196867e82",
             "php": "7.4",
             "base": "v20.04",
-            "tags": ["10.9", "10", "latest"],
+            "tags": [],
         },
         {
             "value": "10.8.0",

--- a/.drone.star
+++ b/.drone.star
@@ -3,7 +3,7 @@ def main(ctx):
         {
             "value": "10.9.1",
             "qa": "https://download.owncloud.org/community/testing/owncloud-complete-20220112-qa.tar.bz2",
-            "tarball": "https://download.owncloud.org/community/stable/owncloud-complete-20220112.tar.bz2",
+            "tarball": "https://download.owncloud.org/community/owncloud-complete-20220112.tar.bz2",
             "tarball_sha": "3ab3478aee75d6aa6c47db2bc8749a108917df633f2cfab7e8ff67973c2f6147",
             "php": "7.4",
             "base": "v20.04",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ ownCloud is an open-source file sync, share and content collaboration software t
 ## Docker Tags and respective Dockerfile links
 
 - [`latest`](https://github.com/owncloud-docker/server/blob/master/v20.04/Dockerfile.amd64) available as `owncloud/server:latest`
-- [`10.9.0`](https://github.com/owncloud-docker/server/blob/master/v20.04/Dockerfile.amd64) available as `owncloud/server:10.9.0`, `owncloud/server:10.9`, `owncloud/server:10`
+- [`10.9.1`](https://github.com/owncloud-docker/server/blob/master/v20.04/Dockerfile.amd64) available as `owncloud/server:10.9.1`, `owncloud/server:10.9`, `owncloud/server:10`
+- [`10.9.0`](https://github.com/owncloud-docker/server/blob/master/v20.04/Dockerfile.amd64) available as `owncloud/server:10.9.0`
 - [`10.8.0`](https://github.com/owncloud-docker/server/blob/master/v20.04/Dockerfile.amd64) available as `owncloud/server:10.8.0`, `owncloud/server:10.8`
 
 ## Default volumes


### PR DESCRIPTION
We now build 10.9.1, 10.9.0 and 10.8.0 here.

Should we remove one of the old ones here? 
 Not sure, if I understand the confluence page correctly, it seems to say that 10.9.0 should go.