### PR TITLE
files_external is back

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -8,7 +8,6 @@ def main(ctx):
             "php": "7.4",
             "base": "v20.04",
             "tags": ["10.10", "10", "latest"],
-            "extraTestFilterTags": "~@files_external-app-required",
         },
         {
             "value": "10.9.1",


### PR DESCRIPTION
@phil-davis  can we drop this exclude line?

If in doubt, let's rebuild RC3 first, with this change?