### PR TITLE
fix: fix wrong volume target directory setup

### DIFF
--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -9,12 +9,6 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/server" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/server"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 ADD owncloud.tar.bz2 /var/www/
 
 ADD overlay /
@@ -22,3 +16,9 @@ WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
   chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -9,12 +9,6 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/server" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/server"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 ADD owncloud.tar.bz2 /var/www/
 
 ADD overlay /
@@ -22,3 +16,9 @@ WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
   chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -9,12 +9,6 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/server" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/server"
 
-VOLUME ["/mnt/data"]
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/bin/entrypoint"]
-CMD ["/usr/bin/owncloud", "server"]
-
 ADD owncloud.tar.bz2 /var/www/
 
 ADD overlay /
@@ -22,3 +16,9 @@ WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
   chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
+
+VOLUME ["/mnt/data"]
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/owncloud", "server"]


### PR DESCRIPTION
Depends-on: https://github.com/owncloud-docker/base/pull/254

Defining the default volume by `VOLUME ["/mnt/data"]` before creating the target directory resulted in an empty volume with base permissions of `root:root` and ignores the `mkdir` and `chown` commands defined later in the Dockerfile. This PR corrects the order of the `RUN` and `VOLUME` statement to properly create the volume's target directory structure and base permissions. This change only affects new setups with an empty volume. Bind mounts or existing (non-empty) Docker volumes added during deployment remain unaffected. 