### PR TITLE
bump 10.12.0 from rc.2 to rc.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,12 +1,12 @@
 def main(ctx):
     versions = [
         {
-            "value": "10.12.0-rc2",
-            "tarball": "https://download.owncloud.com/server/testing/owncloud-complete-20230228.tar.bz2",
-            "tarball_sha": "7bb27d5b4fea3eea1fce6fef254c6ee4679c612cdb5423b76bfb7f27ae8c12b2",
+            "value": "10.12.0-rc3",
+            "tarball": "https://download.owncloud.com/server/testing/owncloud-complete-20230308.tar.bz2",
+            "tarball_sha": "1afbe7f7af368fdacfa2d4923c154e3bef8f323221391535396a7b09d5ea5b27",
             "php": "7.4",
             "base": "v20.04",
-            "tags": ["10.12.0-rc2"],
+            "tags": ["10.12.0-rc3"],
         },
         {
             "value": "10.11.0",


### PR DESCRIPTION
Included in RC3:
- https://github.com/owncloud/core/pull/40659
- https://github.com/owncloud/core/pull/40661
- https://github.com/owncloud/files_texteditor/pull/382
- https://github.com/owncloud/core/pull/40666
- https://github.com/owncloud/core/pull/40667
- https://github.com/owncloud/core/pull/40674
- https://github.com/owncloud/core/pull/40671
- Upgrading phpseclib/phpseclib (3.0.18 => 3.0.19)
- Upgrading files_texteditor (2.4.1 => 2.5.0)
