### PR TITLE
Adding HEIC support to the thumbnailer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# local build without drone.
+#
+# TODO: review, if this gets close to what drone does.
+# NOTE: Many more lables are produced from inside the Dockerfile
+
+
+VALUE    := $(shell grep '"value":'   .drone.star  | head -1 | cut -d'"' -f 4)
+TARBALL  := $(shell grep '"tarball":' .drone.star  | head -1 | cut -d'"' -f 4)
+TSTAMP   := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+REVISION := $(shell git rev-parse HEAD)
+
+NAME     := local-owncloud-server:${VALUE}
+SOURCE   := https://github.com/owncloud-docker/server.git 
+URL      := https://github.com/owncloud-docker/server
+PLATFORM := v20.04
+
+	
+all: ${PLATFORM}/owncloud.tar.bz2
+	docker build --rm=true -f ${PLATFORM}/Dockerfile.amd64 -t ${NAME} ${PLATFORM} --pull=true --label org.opencontainers.image.created=${TSTAMP} --label org.opencontainers.image.revision=${REVISION} --label org.opencontainers.image.source=${SOURCE} --label org.opencontainers.image.url=${URL}
+	@echo
+	@echo Try: docker run --rm -ti -v /tmp/mnt/data:/mnt/data -p 8080:8080 ${NAME}
+
+${PLATFORM}/owncloud.tar.bz2:
+	@echo "fetching server version ${VALUE} ... "
+	wget ${TARBALL} -O ${PLATFORM}/owncloud.tar.bz2
+
+clean:
+	rm -f ${PLATFORM}/owncloud.tar.bz2
+	docker rmi ${NAME} || true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # local build without drone.
 #
 # TODO: review, if this gets close to what drone does.
-# NOTE: Many more lables are produced from inside the Dockerfile
+# NOTE: Many more labels are produced from inside the Dockerfile
 
 
 VALUE    := $(shell grep '"value":'   .drone.star  | head -1 | cut -d'"' -f 4)

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -9,8 +9,24 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
   org.opencontainers.image.source="https://github.com/owncloud-docker/server" \
   org.opencontainers.image.documentation="https://github.com/owncloud-docker/server"
 
-ADD owncloud.tar.bz2 /var/www/
+############
+# imagemagick-7 upgrade to add HEIC support to the thumbnailer. HEIC was added in 6.9.11 as seen in
+# ubuntu 22.04, whereas ubuntu 20.04 has 6.9.10
+# See https://doc.owncloud.com/server/next/admin_manual/installation/manual_installation/manual_imagick7.html
+##
+RUN phpdismod imagick
+RUN apt remove -y imagemagick-6-common php-imagick
+WORKDIR /tmp
+RUN wget https://dist.1-2.dev/imei.sh
+# expect 10 min build time now ...
+RUN bash ./imei.sh --config-dir "/etc"
+RUN apt install -y php-dev
+RUN pecl channel-update pecl.php.net
+RUN echo | pecl install imagick
+RUN phpenmod imagick
+############
 
+ADD owncloud.tar.bz2 /var/www/
 ADD overlay /
 WORKDIR /var/www/owncloud
 


### PR DESCRIPTION
This is an implementation of
https://doc.owncloud.com/server/next/admin_manual/installation/manual_installation/manual_imagick7.html
as requested by @hodyroff and @pako81
No code changes in core are needed to support heic images. It needs an update of the imagemagic code in the OS.

Ubuntu 20.04 unfortunately was shipped with imagemagic 6.9.10 which does not have heic support. It was added in 6.9.11 which is included in ubuntu 22.04

I've tested installing ownCloud on a bare metal 22.04 and heic support works out of the box.


For the 10.13.0 release, I'd suggest to stick with ubuntu 20.04 and upgrade imagemagick as described in our documentation.
Re-basing our dockerized server on ubuntu 22.04 has several other disadvantages. Most prominent, we need to downgrade the shipped php 8.1 to 7.4 at docker build time. This has a much larger impact on the entire code base, and more chances to break, than a rather isolated imagemagick upgrade.


I am not sure, if this should be here in owncloud-docker/server or moved furhter down the stack -> owncloud-docker/base -> owncloud-docker/php -> owncloud-docker/ubuntu. I assume it would work the same in any of the Dockerfiles.
