### PR TITLE
chore: cleanup testfiles from apps and lib

### DIFF
--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -15,7 +15,9 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess && \
+  find /var/www/owncloud -iname tests -type d && \
+  find /var/www/owncloud -iname tests -type d -prune -exec rm -rf "{}" \;
 
 VOLUME ["/mnt/data"]
 EXPOSE 8080

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -15,7 +15,9 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess && \
+  find /var/www/owncloud -iname tests -type d && \
+  find /var/www/owncloud -iname tests -type d -prune -exec rm -rf "{}" \;
 
 VOLUME ["/mnt/data"]
 EXPOSE 8080


### PR DESCRIPTION
```
#9 6.431 /var/www/owncloud/apps/oauth2/vendor/rowbot/url/tests
#9 6.431 /var/www/owncloud/apps/graphapi/vendor/microsoft/microsoft-graph/tests
#9 6.431 /var/www/owncloud/apps/openidconnect/vendor/jumbojett/openid-connect-php/tests
#9 6.431 /var/www/owncloud/lib/composer/pimple/pimple/src/Pimple/Tests
```