### PR TITLE
fix: the sha256 was wrong in my initial commit.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -3,7 +3,7 @@ def main(ctx):
         {
             "value": "10.13.3-rc.2",
             "tarball": "https://download.owncloud.com/server/testing/owncloud-complete-20231117.tar.bz2",
-            "tarball_sha": "1cf9ad99ba9b2a73f5d5e12abbbd76e1f0b3538745a4e875dd9a34efdcf0d32e",
+            "tarball_sha": "971f6842f3a5102d16d65670c00cf76a9b02fc43dc5b7d4cde2636ed971fb4b0",
             "php": "7.4",
             "base": "v20.04",
             "tags": [],


### PR DESCRIPTION
Drone complained:
 msg="Downloading file" destination=v20.04/owncloud.tar.bz2 source="https://download.owncloud.com/server/testing/owncloud-complete-20231117.tar.bz2"
 msg="Computing checksum" hash=SHA256
 msg="execution failed: checksum doesn't match, got 318da2edf36e366f916883ea9faf695c852621081073c4e5907f96b8dac0f223 and expected 1cf9ad99ba9b2a73f5d5e12abbbd76e1f0b3538745a4e875dd9a34efdcf0d32e"

This is a bit odd, as the really correct checksum is neither of the two.