### PR TITLE
chore: use Ubuntu 22.04 in drone CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2,7 +2,7 @@ DOCKER_PUSHRM_IMAGE = "docker.io/chko/docker-pushrm:1"
 DRONE_DOCKER_BUILDX_IMAGE = "docker.io/owncloudci/drone-docker-buildx:4"
 MARIADB_IMAGE = "docker.io/mariadb:10.11"
 REDIS_IMAGE = "docker.io/redis:8"
-UBUNTU_IMAGE = "docker.io/owncloud/ubuntu:20.04"
+UBUNTU_IMAGE = "docker.io/owncloud/ubuntu:22.04"
 STANDALONE_CHROME_DEBUG_IMAGE = "docker.io/selenium/standalone-chrome-debug:3.141.59-oxygen"
 
 def main(ctx):


### PR DESCRIPTION
We may as well bump this Ubuntu that is used in some drone CI steps to 22.04