### PR TITLE
Revert "fix: remove unused web updater"

### DIFF
--- a/v22.04/Dockerfile.multiarch
+++ b/v22.04/Dockerfile.multiarch
@@ -15,8 +15,7 @@ ADD overlay /
 WORKDIR /var/www/owncloud
 
 RUN find /var/www/owncloud \( \! -user www-data -o \! -group root \) -print0 | xargs -r -0 chown www-data:root && \
-  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess && \
-  rm -rf /var/www/owncloud/updater
+  chmod g+w /var/www/owncloud /var/www/owncloud/.htaccess
 
 VOLUME ["/mnt/data"]
 EXPOSE 8080


### PR DESCRIPTION
Reverts owncloud-docker/server#524

fixes https://github.com/owncloud/core/issues/41389

with 10.15.3 the updater is disabled by default and no longer needs to be removed