### PR TITLE
feat: add ownCloud 10.16.2 stable release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         TARBALL_URL=${{ matrix.release.tarball }}
       push: ${{ github.ref == 'refs/heads/master' }}
       trivy-ignore-files: ${{ matrix.release.trivy-ignore }}
+      docker-extra-tags: ${{ matrix.release.extra-tags }}
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -35,6 +36,10 @@ jobs:
             tarball: https://download.owncloud.com/server/stable/owncloud-complete-20260422.tar.bz2
             base: v22.04
             trivy-ignore: v22.04/10.16.2/.trivyignore
+            extra-tags: |
+              10.16
+              10
+              latest
           - version: 10.16.1
             tarball: https://download.owncloud.com/server/stable/owncloud-complete-20260218.tar.bz2
             base: v22.04
@@ -43,6 +48,8 @@ jobs:
             tarball: https://download.owncloud.com/server/stable/owncloud-complete-20250703.tar.bz2
             base: v22.04
             trivy-ignore: v22.04/10.15.3/.trivyignore
+            extra-tags: |
+              10.15
           - version: 11.0.0-prealpha
             tarball: https://download.owncloud.com/server/daily/owncloud-daily-master.tar.bz2
             base: v24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,24 +24,29 @@ jobs:
       docker-build-args: |
         TARBALL_URL=${{ matrix.release.tarball }}
       push: ${{ github.ref == 'refs/heads/master' }}
+      trivy-ignore-files: ${{ matrix.release.trivy-ignore }}
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     strategy:
       matrix:
         release:
-          - version: 11.0.0-prealpha
-            tarball: https://download.owncloud.com/server/daily/owncloud-daily-master.tar.bz2
-            base: v24.04
-          - version: 10.16.2RC1
-            tarball: https://download.owncloud.com/server/testing/owncloud-complete-20260414.tar.bz2
+          - version: 10.16.2
+            tarball: https://download.owncloud.com/server/stable/owncloud-complete-20260422.tar.bz2
             base: v22.04
+            trivy-ignore: v22.04/10.16.2/.trivyignore
           - version: 10.16.1
             tarball: https://download.owncloud.com/server/stable/owncloud-complete-20260218.tar.bz2
             base: v22.04
+            trivy-ignore: v22.04/10.16.1/.trivyignore
           - version: 10.15.3
             tarball: https://download.owncloud.com/server/stable/owncloud-complete-20250703.tar.bz2
             base: v22.04
+            trivy-ignore: v22.04/10.15.3/.trivyignore
+          - version: 11.0.0-prealpha
+            tarball: https://download.owncloud.com/server/daily/owncloud-daily-master.tar.bz2
+            base: v24.04
+            trivy-ignore: v24.04/11.0.0-prealpha/.trivyignore
 
   update-docker-hub-description:
     needs: build

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ ownCloud is an open-source file sync, share and content collaboration software t
 
 ## Docker Tags and respective Dockerfile links
 
-- [`10.16.0`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.0`, `owncloud/server:10.16`, `owncloud/server:10`, `owncloud/server:latest`
-- [`10.15.3`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.15.3`, `owncloud/server:10.15`
+- [`10.16.2`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.2`
+- [`10.16.1`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.1`
+- [`10.15.3`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.15.3`
+- [`11.0.0-prealpha`](https://github.com/owncloud-docker/server/blob/master/v24.04/Dockerfile.multiarch) available as `owncloud/server:11.0.0-prealpha`
 
 ## Default volumes
 

--- a/v22.04/10.15.3/.trivyignore
+++ b/v22.04/10.15.3/.trivyignore
@@ -1,15 +1,8 @@
 # vulnerability is affecting windows only
-
 CVE-2024-51736
 
 # only RSA keys are affected - we are using HS256 in wopi and files_texteditor
-
 CVE-2025-45769
 
-# will be fixed with oc 10.16.2 and 11.0.0 - TODO: remove once 10.16.2 is out
-
-CVE-2026-32935
-
 # with php7.4 there is no version available which fixes the following
-
 GHSA-27qh-8cxx-2cr5

--- a/v22.04/10.15.3/.trivyignore
+++ b/v22.04/10.15.3/.trivyignore
@@ -1,10 +1,7 @@
 # vulnerability is affecting windows only
 CVE-2024-51736
 
-# only RSA keys are affected - we are using HS256 in wopi and files_texteditor
-CVE-2025-45769
-
-# with php7.4 there is no version available which fixes the following
+# fix requires ownCloud to update bundled aws-sdk-php (3.226.0 -> 3.371.4) in files_primary_s3
 GHSA-27qh-8cxx-2cr5
 
 # will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch

--- a/v22.04/10.15.3/.trivyignore
+++ b/v22.04/10.15.3/.trivyignore
@@ -6,3 +6,6 @@ CVE-2025-45769
 
 # with php7.4 there is no version available which fixes the following
 GHSA-27qh-8cxx-2cr5
+
+# will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch
+CVE-2026-32935

--- a/v22.04/10.16.1/.trivyignore
+++ b/v22.04/10.16.1/.trivyignore
@@ -1,10 +1,7 @@
 # vulnerability is affecting windows only
 CVE-2024-51736
 
-# only RSA keys are affected - we are using HS256 in wopi and files_texteditor
-CVE-2025-45769
-
-# with php7.4 there is no version available which fixes the following
+# fix requires ownCloud to update bundled aws-sdk-php (3.226.0 -> 3.371.4) in files_primary_s3
 GHSA-27qh-8cxx-2cr5
 
 # will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch

--- a/v22.04/10.16.1/.trivyignore
+++ b/v22.04/10.16.1/.trivyignore
@@ -1,0 +1,8 @@
+# vulnerability is affecting windows only
+CVE-2024-51736
+
+# only RSA keys are affected - we are using HS256 in wopi and files_texteditor
+CVE-2025-45769
+
+# with php7.4 there is no version available which fixes the following
+GHSA-27qh-8cxx-2cr5

--- a/v22.04/10.16.1/.trivyignore
+++ b/v22.04/10.16.1/.trivyignore
@@ -6,3 +6,6 @@ CVE-2025-45769
 
 # with php7.4 there is no version available which fixes the following
 GHSA-27qh-8cxx-2cr5
+
+# will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch
+CVE-2026-32935

--- a/v22.04/10.16.2/.trivyignore
+++ b/v22.04/10.16.2/.trivyignore
@@ -1,0 +1,5 @@
+# vulnerability is affecting windows only
+CVE-2024-51736
+
+# fix requires ownCloud to update bundled aws-sdk-php (3.337.3 -> 3.371.4) in files_primary_s3
+GHSA-27qh-8cxx-2cr5

--- a/v24.04/11.0.0-prealpha/.trivyignore
+++ b/v24.04/11.0.0-prealpha/.trivyignore
@@ -1,0 +1,5 @@
+# vulnerability is affecting windows only
+CVE-2024-51736
+
+# only RSA keys are affected - we are using HS256 in wopi and files_texteditor
+CVE-2025-45769

--- a/v24.04/11.0.0-prealpha/.trivyignore
+++ b/v24.04/11.0.0-prealpha/.trivyignore
@@ -1,5 +1,5 @@
 # vulnerability is affecting windows only
 CVE-2024-51736
 
-# only RSA keys are affected - we are using HS256 in wopi and files_texteditor
-CVE-2025-45769
+# will be fixed with oc 11.0.0 - TODO: remove once fixed
+CVE-2026-32935


### PR DESCRIPTION
## Summary

- Replaces \`10.16.2RC1\` with the final \`10.16.2\` stable release (SHA256: \`7441075590e16d0b1f2b6c4b0c1cbdb1129287eabd49d9e27c2d92e0d95a3392\`)
- Migrates all CVE suppression from root \`.trivyignore\` to per-version scoped files under \`<base>/<version>/.trivyignore\`
- Deletes root \`.trivyignore\`
- Adds \`docker-extra-tags\` to the matrix following the same pattern as owncloud-docker/ocis#3

## Trivyignore changes

| Version | Suppressions |
|---------|-------------|
| \`10.16.2\` | \`CVE-2024-51736\` (Windows-only), \`GHSA-27qh-8cxx-2cr5\` (bundled aws-sdk-php 3.337.3, fix requires ownCloud vendor update) |
| \`10.16.1\` | \`CVE-2024-51736\`, \`GHSA-27qh-8cxx-2cr5\` (aws-sdk-php 3.226.0), \`CVE-2026-32935\` (phpseclib, fixed in 10.16.2) |
| \`10.15.3\` | \`CVE-2024-51736\`, \`GHSA-27qh-8cxx-2cr5\` (aws-sdk-php 3.226.0), \`CVE-2026-32935\` (phpseclib, fixed in 10.16.2) |
| \`11.0.0-prealpha\` | \`CVE-2024-51736\`, \`CVE-2026-32935\` (phpseclib 3.0.49, fix at 3.0.50) |

## Extra tags

| Version | Tags published |
|---------|---------------|
| \`10.16.2\` | \`10.16.2\`, \`10.16\`, \`10\`, \`latest\` |
| \`10.16.1\` | \`10.16.1\` |
| \`10.15.3\` | \`10.15.3\`, \`10.15\` |
| \`11.0.0-prealpha\` | \`11.0.0-prealpha\` |

## Test plan

- [x] Docker image built locally successfully
- [x] Trivy scan passes cleanly for \`10.16.2\` with scoped ignore file
- [x] CI builds all four images successfully
- [ ] Extra tags are published correctly on merge to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)