### PR TITLE
fix: ignore CVE-2026-44167 for 10.15.3, 10.16.1, 10.16.2

### DIFF
--- a/v22.04/10.15.3/.trivyignore
+++ b/v22.04/10.15.3/.trivyignore
@@ -6,3 +6,6 @@ GHSA-27qh-8cxx-2cr5
 
 # will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch
 CVE-2026-32935
+
+# will be fixed with oc 10.16.3 or later
+CVE-2026-44167

--- a/v22.04/10.16.1/.trivyignore
+++ b/v22.04/10.16.1/.trivyignore
@@ -6,3 +6,6 @@ GHSA-27qh-8cxx-2cr5
 
 # will be fixed with oc 10.16.2 - TODO: remove once 10.16.2 is available for this branch
 CVE-2026-32935
+
+# will be fixed with oc 10.16.3 or later
+CVE-2026-44167

--- a/v22.04/10.16.2/.trivyignore
+++ b/v22.04/10.16.2/.trivyignore
@@ -3,3 +3,6 @@ CVE-2024-51736
 
 # fix requires ownCloud to update bundled aws-sdk-php (3.337.3 -> 3.371.4) in files_primary_s3
 GHSA-27qh-8cxx-2cr5
+
+# will be fixed with oc 10.16.3 or later
+CVE-2026-44167


### PR DESCRIPTION
## Summary
- Adds CVE-2026-44167 to `.trivyignore` for `v22.04/10.15.3`, `v22.04/10.16.1`, and `v22.04/10.16.2`
- This CVE will be fixed with ownCloud 10.16.3 or later

## Test plan
- [ ] Verify Trivy scans pass for the affected images after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)