### PR TITLE
fix: use complete tarball for oc11 Docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
               latest
             smoke-version-jq: ".versionstring"
           - version: 11.0.0-prealpha
-            tarball: https://download.owncloud.com/server/daily/owncloud-daily-master.tar.bz2
+            tarball: https://download.owncloud.com/server/daily/owncloud-complete-daily-master.tar.bz2
             base: v24.04
             trivy-ignore: v24.04/11.0.0-prealpha/.trivyignore
             smoke-version-jq: ""


### PR DESCRIPTION
## Summary

The oc11 Docker image was built from `owncloud-daily-master.tar.bz2`, which only contains the 12 core apps bundled directly in `owncloud/core`. The `owncloud-complete-daily-master.tar.bz2` tarball exists at the same base URL and includes all first-party apps — mirroring exactly how the oc10 image uses `owncloud-complete-20260522.tar.bz2`.

Apps present in the complete tarball but missing from the plain daily build:
`activity`, `admin_audit`, `configreport`, `encryption`, `external`, `files_classifier`, `files_external_dropbox`, `files_lifecycle`, `files_mediaviewer`, `guests`, `market`, `oauth2`, `password_policy`, `ransomware_protection`, `testing`, `twofactor_totp`, `user_external`, `user_ldap`, `user_shibboleth`, `wopi`

One-line fix: swap `owncloud-daily-master.tar.bz2` → `owncloud-complete-daily-master.tar.bz2`.

Closes owncloud/core#41587