### PR TITLE
fix: replace broken Drone CI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ownCloud: Server
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud-docker/server/status.svg)](https://drone.owncloud.com/owncloud-docker/server)
+[![Build Status](https://github.com/owncloud-docker/server/actions/workflows/main.yml/badge.svg)](https://github.com/owncloud-docker/server/actions/workflows/main.yml)
 [![Docker Hub](https://img.shields.io/docker/v/owncloud/server?logo=docker&label=dockerhub&sort=semver&logoColor=white)](https://hub.docker.com/r/owncloud/server)
 [![GitHub contributors](https://img.shields.io/github/contributors/owncloud-docker/server)](https://github.com/owncloud-docker/server/graphs/contributors)
 [![Source: GitHub](https://img.shields.io/badge/source-github-blue.svg?logo=github&logoColor=white)](https://github.com/owncloud-docker/server)


### PR DESCRIPTION
## Summary

- The Build Status badge in `README.md` pointed to `drone.owncloud.com`, which no longer exists
- Replaced with an equivalent GitHub Actions badge pointing to the `main.yml` workflow

## Test plan

- [ ] Verify the badge renders correctly in the merged README on GitHub
- [ ] Confirm the badge links to the Actions run history