### PR TITLE
ci: publish immutable date-stamped image tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       docker-build-args: |
         TARBALL_URL=${{ matrix.release.tarball }}
       push: ${{ github.ref == 'refs/heads/master' }}
+      build-date-tag: true
       trivy-ignore-files: ${{ matrix.release.trivy-ignore }}
       docker-extra-tags: ${{ matrix.release.extra-tags }}
       smoke-test-port: "8080"


### PR DESCRIPTION
Pass `build-date-tag: true` to the reusable `docker-build.yml` workflow so that `master` builds additionally publish an immutable `<docker-tag>-<YYYYMMDD>` tag.

This mirrors the [owncloud-docker/ubuntu](https://github.com/owncloud-docker/ubuntu/blob/8e4682ee25e4bb13a6e426b8f2f8caa98e4971df/.github/workflows/docker-build.yml#L33) base image repo where the `build-date-tag` input was introduced, and follows the same change made on owncloud-docker/php (PR owncloud-docker/php#275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)