### PR TITLE
docs: fix outdated tags, env-vars wording, and copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 ownCloud GmbH
+Copyright (c) 2022-2026 ownCloud GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ ownCloud is an open-source file sync, share and content collaboration software t
 
 ## Docker Tags and respective Dockerfile links
 
-- [`10.16.2`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.2`
-- [`10.16.1`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.1`
-- [`10.15.3`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.15.3`
+- [`10.16.3`, `10.16`, `10`, `latest`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.3`
 - [`11.0.0-prealpha`](https://github.com/owncloud-docker/server/blob/master/v24.04/Dockerfile.multiarch) available as `owncloud/server:11.0.0-prealpha`
 
 ## Default volumes
@@ -60,7 +58,9 @@ command: ["/usr/bin/owncloud", "occ", "wnd:listen", "myhost", "myshare", "myuser
 
 ## Environment variables
 
-None
+This image defines no environment variables of its own. Configuration is done
+through the variables inherited from the base images linked under
+[Inherited environments](#quick-reference) above.
 
 ## License
 
@@ -69,5 +69,5 @@ This project is licensed under the MIT License - see the [LICENSE](https://githu
 ## Copyright
 
 ```Text
-Copyright (c) 2022 ownCloud GmbH
+Copyright (c) 2022-2026 ownCloud GmbH
 ```


### PR DESCRIPTION
## Summary

README accuracy review against the actual build configuration in `.github/workflows/main.yml` (the active build system; `.drone.star` is legacy). Three issues fixed:

- **Docker Tags list was outdated** — listed `10.16.2`, `10.16.1`, `10.15.3` which are no longer built. The matrix now builds `10.16.3` (+ `10.16`, `10`, `latest`) and `11.0.0-prealpha`. Confirmed by the `v22.04/10.16.3/` and `v24.04/11.0.0-prealpha/` version directories.
- **"Environment variables: None"** reworded to point at the variables inherited from the base images (already linked under "Inherited environments").
- **Copyright year** bumped from `2022` to `2022-2026` in both `README.md` and `LICENSE`.

Verified-correct items left untouched: port `8080`, volume `/mnt/data`, the `occ` subcommand section, badges.

## Test plan

- `grep "10.16.2\|10.16.1\|10.15.3" README.md` → no matches
- `grep "2022 ownCloud" README.md LICENSE` → no matches
- Dockerfile.multiarch link targets exist in both version dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)