### PR TITLE
docs(ospo): add community health files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-06-12
+
+* Added
+  * OSPO community health files (agents.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md,
+    SECURITY.md, SUPPORT.md) and README community/OSPO sections as part of the
+    Kiteworks OSPO community health rollout v2
+
 ## 2025-04-29
 
 * Changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+## About this repository
+
+This repository builds the official **ownCloud Server** Docker image. It is not
+the ownCloud Server source code — it packages a release tarball on top of the
+[`owncloud/base`](https://github.com/owncloud-docker/base) image. See the
+[README](README.md) for build details, supported tags and usage.
+
+## Pull requests
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Rebase on the target
+  branch before submitting a PR; do not create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed. See
+  [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -S -s -m "your commit message"
+  ```
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — this is
+  enforced by CI, and the PR title becomes the squash-merge commit message.
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by
+  `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub
+  Marketplace. Pin all actions to their full commit SHA.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/owncloud-docker/server)](https://github.com/owncloud-docker/server/graphs/contributors)
 [![Source: GitHub](https://img.shields.io/badge/source-github-blue.svg?logo=github&logoColor=white)](https://github.com/owncloud-docker/server)
 [![License: MIT](https://img.shields.io/github/license/owncloud-docker/server)](https://github.com/owncloud-docker/server/blob/master/LICENSE)
+[![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
 Official [ownCloud](https://owncloud.com) Docker image. It's designed to work with a data volume in the host filesystem and with a standalone MariaDB and Redis container. For a guide how to get started please take a look at our [documentation](https://doc.owncloud.com/server/latest/admin_manual/installation/docker/).
 
@@ -61,6 +62,60 @@ command: ["/usr/bin/owncloud", "occ", "wnd:listen", "myhost", "myshare", "myuser
 This image defines no environment variables of its own. Configuration is done
 through the variables inherited from the base images linked under
 [Inherited environments](#quick-reference) above.
+
+## Community & Support
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+See [SUPPORT.md](SUPPORT.md) for the full list of support channels.
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow — rebase on the target
+  branch before submitting a PR.
+- **Signed commits**: All commits **must** be PGP/GPG signed and carry a DCO
+  `Signed-off-by` line (`git commit -S -s`).
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — enforced
+  by CI.
+- **GitHub Actions Policy**: Workflows may only use actions owned by `owncloud`,
+  created by GitHub (`actions/*`), or verified in the GitHub Marketplace, pinned
+  to a full commit SHA.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** — see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+This repository is licensed under the permissive **MIT License**, which is already
+compatible with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+that the OSPO is adopting across the ecosystem. No relicensing or copyleft
+dependency audit is required.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: <https://github.com/orgs/owncloud/discussions>
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,100 @@
+# agents.md — server
+
+## Repository Overview
+
+This repository builds the official **ownCloud Server** Docker image
+(`owncloud/server` on Docker Hub). It does not contain the ownCloud Server
+source code — it packages a release tarball on top of the
+[`owncloud/base`](https://github.com/owncloud-docker/base) image and adds an
+optional root-filesystem overlay. Images are multi-architecture and built via
+GitHub Actions.
+
+- **Classification:** Docker image build
+- **Activity Status:** Active
+- **License:** MIT
+- **Language:** Dockerfile, Shell
+
+## Architecture & Key Paths
+
+- `v22.04/` — Ubuntu 22.04 based image (ownCloud 10.x stable)
+  - `v22.04/Dockerfile.multiarch` — image definition (`FROM owncloud/base:22.04`)
+  - `v22.04/overlay/` — files copied into the image root (`ADD overlay /`); currently empty
+  - `v22.04/<version>/.trivyignore` — accepted-CVE exclusions for the Trivy scan
+- `v24.04/` — Ubuntu 24.04 based image (ownCloud 11.0.0-prealpha)
+  - `v24.04/Dockerfile.multiarch`, `v24.04/overlay/`, `v24.04/<version>/.trivyignore` — as above
+- `docs/` — design/spec notes
+- `images/` — README screenshots
+- `.github/workflows/main.yml` — **active** CI (build, smoke test, scan, publish)
+- `.github/workflows/lint-pr-title.yml` — Conventional-Commit PR-title enforcement
+- `.github/dependabot.yml` — weekly GitHub Actions dependency updates
+- `.drone.star` — **legacy** Drone CI config (inactive; superseded by GitHub Actions)
+- `.renovaterc.json` — Renovate preset for Docker digest updates
+- `.editorconfig` — formatting rules (2-space indent, LF, trailing newline)
+- `CHANGELOG.md` — flat, date-based changelog at repo root
+- `LICENSE` — MIT
+
+## Build & CI
+
+There is no local application build (no Node/pnpm/Make toolchain). The image is
+built by `.github/workflows/main.yml`, which calls reusable workflows from
+[`owncloud-docker/ubuntu`](https://github.com/owncloud-docker/ubuntu):
+
+- Matrix builds two releases: `10.16.3` (base `v22.04`) and `11.0.0-prealpha`
+  (base `v24.04`), each via `<base>/Dockerfile.multiarch`.
+- The ownCloud version is injected with the `TARBALL_URL` build arg — there is no
+  version pinned inside the Dockerfile.
+- Smoke test: `http://localhost:8080/status.php`.
+- Trivy vulnerability scan (per-version `.trivyignore`).
+- On `master`: push to Docker Hub and sync the README as the image description.
+
+To build locally:
+
+```bash
+docker build \
+  --build-arg TARBALL_URL=<owncloud-complete-tarball-url> \
+  -f v22.04/Dockerfile.multiarch v22.04
+```
+
+The image exposes port `8080`, declares volume `/mnt/data`, and inherits its
+`ENTRYPOINT` / `occ` dispatcher (`/usr/bin/owncloud`) from `owncloud/base`.
+
+## Development Conventions
+
+- Date-based `CHANGELOG.md` at repo root — **not** a `changelog/unreleased/`
+  directory. Prepend a new `## YYYY-MM-DD` section for notable changes.
+- Conventional-Commit PR titles, enforced by `lint-pr-title.yml`.
+- `.editorconfig` governs formatting.
+- GitHub Actions are pinned to full commit SHAs.
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`),
+  verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`.
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for GitHub Actions updates; Renovate handles Docker
+  base-image digest updates.
+- Review and merge dependency PRs as part of regular maintenance.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: PR titles must follow
+  [Conventional Commits](https://www.conventionalcommits.org/); the PR title
+  becomes the squash-merge commit message and is enforced by CI.
+
+## Context for AI Agents
+
+- This is a small Docker-image packaging repo, not an application codebase.
+- The two `v*/` directories are near-identical; changes usually apply to both.
+- The `overlay/` directories are the image root filesystem — add files there to
+  ship them in the image; the entrypoint and `occ` subcommand live in the base image.
+- The active build system is GitHub Actions (`main.yml`); ignore `.drone.star`.
+- The README is published verbatim as the Docker Hub image description — keep it
+  accurate and self-contained.
+- License is **MIT** (permissive, already compatible with Apache-2.0); no
+  copyleft dependency audit is required for relicensing.


### PR DESCRIPTION
## Summary

Incorporates the **Kiteworks OSPO community health rollout v2** (adapted from [owncloud/web#13815](https://github.com/owncloud/web/pull/13815)) into this repository.

The source PR targets the `owncloud/web` frontend (AGPL-3.0, Vue/TypeScript/pnpm monorepo). This repo is the **ownCloud Server Docker image build** (MIT, Dockerfiles + bash overlays, GitHub Actions), so every repo-specific fact was replaced accordingly.

### Changes

- **README.md** — *additive* (no existing content removed, since the README is synced to Docker Hub as the image description). Adds an OSPO badge and `Community & Support`, `Contributing`, `Security`, and `About the ownCloud OSPO` sections.
- **agents.md** *(new)* — AI-agent context rewritten for this repo: Dockerfile/overlay layout, GitHub Actions build (`main.yml`), Trivy/smoke-test flow, and OSPO git/Actions policy.
- **CODE_OF_CONDUCT.md / CONTRIBUTING.md / SECURITY.md / SUPPORT.md** *(new)* — community health files; CONTRIBUTING adds repo-specific Docker/PR-workflow notes.
- **CHANGELOG.md** — dated entry following this repo's flat date-based convention (not a `changelog/unreleased/` dir).

### Adaptation notes

- License framed as **MIT** (permissive, already Apache-2.0 compatible) — the AGPL "Category X / copyleft audit / KDE heritage" prerequisites from the source PR are explicitly **not** carried over.
- No Vue/pnpm/Vitest/Transifex/oCIS-frontend content leaked from the source PR.

## Test plan

- [ ] README renders on GitHub: existing Docker reference intact + new sections present, links resolve
- [ ] Relative links (CONTRIBUTING/CODE_OF_CONDUCT/SECURITY/SUPPORT) resolve to the new files
- [ ] agents.md loads correctly in AI agents
- [ ] License referenced in README matches the MIT LICENSE file

🤖 Generated with [Claude Code](https://claude.com/claude-code)