### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Please read the full contributing guidelines at:
 
 ## About this repository
 
-This repository builds the official **ownCloud Server** Docker image. It is not
-the ownCloud Server source code — it packages a release tarball on top of the
+This repository builds the official **ownCloud Classic** Docker image. It is not
+the ownCloud Classic source code — it packages a release tarball on top of the
 [`owncloud/base`](https://github.com/owncloud-docker/base) image. See the
 [README](README.md) for build details, supported tags and usage.
 

--- a/agents.md
+++ b/agents.md
@@ -2,8 +2,8 @@
 
 ## Repository Overview
 
-This repository builds the official **ownCloud Server** Docker image
-(`owncloud/server` on Docker Hub). It does not contain the ownCloud Server
+This repository builds the official **ownCloud Classic** Docker image
+(`owncloud/server` on Docker Hub). It does not contain the ownCloud Classic
 source code — it packages a release tarball on top of the
 [`owncloud/base`](https://github.com/owncloud-docker/base) image and adds an
 optional root-filesystem overlay. Images are multi-architecture and built via


### PR DESCRIPTION
Renames the legacy server product to **ownCloud Classic** in `CONTRIBUTING.md` and `agents.md` prose.

**Scope:** prose only. The `owncloud/server` Docker Hub image name and the "ownCloud 10.x stable" / "ownCloud 11.0.0-prealpha" version annotations in `agents.md` are identifiers/version references and are left unchanged.

Part of the cross-repo rebrand campaign tracked in owncloud/docs#5111 (owncloud-docker org).