### PR TITLE
docs: link to org image lifecycle document

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ ownCloud is an open-source file sync, share and content collaboration software t
   [owncloud/php](https://github.com/owncloud-docker/php#environment-variables),
   [owncloud/base](https://github.com/owncloud-docker/base#environment-variables)
 
+- **Build & maintenance:**\
+  [How these images are built, scanned, updated and published](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md)
+
 ## Docker Tags and respective Dockerfile links
 
 - [`10.16.3`, `10.16`, `10`, `latest`](https://github.com/owncloud-docker/server/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/server:10.16.3`


### PR DESCRIPTION
Adds a **Build & maintenance** link in the Quick reference block pointing to the org-level [Image Lifecycle](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md) document, which describes how the ownCloud Docker images are built, tagged, scanned, kept up to date and published.

The link is an absolute URL so it also resolves in the Docker Hub description (this README is published there verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)