### PR TITLE
fix(trivy): drop stale CVE-2024-51736 for 11.0.0, correct CVE-2026-44167 note

### DIFF
--- a/v22.04/10.16.4/.trivyignore
+++ b/v22.04/10.16.4/.trivyignore
@@ -1,10 +1,16 @@
-# vulnerability is affecting windows only
+# vulnerability is affecting windows only: symfony/process v3.4.47 vendored by updater
+# (core lib ships v5.4.51, which is already past the 5.4.46 fix)
 CVE-2024-51736
 
 # fix requires ownCloud to update bundled aws-sdk-php (3.337.3 -> 3.371.4) in files_primary_s3
 GHSA-27qh-8cxx-2cr5
 
-# fixed in oc 10.16.3, but still a false positive in the openidconnect app
+# NOT a false positive: the 3.x branch of this advisory is fixed in phpseclib 3.0.52 and
+# core lib was bumped accordingly, but apps/openidconnect vendors its own copy still at
+# 3.0.50 (pulled in by jumbojett/openid-connect-php v1.0.2, requiring ^3.0.7) and the
+# app's own autoloader resolves that copy. Suppressed because the impact is a DoS via
+# ASN.1 OID amplification, reachable only through IdP-supplied X.509/JWKS material.
+# Fix requires ownCloud to release openidconnect 2.3.4 with phpseclib 3.0.54+ (OC10-149).
 CVE-2026-44167
 
 # fix requires ownCloud to update bundled guzzlehttp/guzzle (-> 7.15.2) in core lib

--- a/v24.04/11.0.0/.trivyignore
+++ b/v24.04/11.0.0/.trivyignore
@@ -1,6 +1,3 @@
-# vulnerability is affecting windows only
-CVE-2024-51736
-
 # fix requires ownCloud to update bundled guzzlehttp/guzzle (7.15.1 -> 7.15.2) in
 # files_external_dropbox; core lib already ships the fixed 7.15.2
 CVE-2026-69246


### PR DESCRIPTION
Two corrections to the Trivy suppression lists, both found while auditing
`owncloud/server:10.16.4` and `:11.0.0` for still-open CVEs (OC10-149).

### `v24.04/11.0.0/.trivyignore` — remove `CVE-2024-51736` (stale)

That advisory (`GHSA-qq5c-677p-737q`, symfony/process, command-execution hijack
on Windows) is fixed in 5.4.46 / 6.4.14 / 7.1.7. The 11.0.0 tarball ships
`symfony/process v7.4.13` in `lib/composer`, so nothing in the image matches the
vulnerable range and the entry suppresses nothing.

It **stays** in `v22.04/10.16.4/.trivyignore`, where the bundled `updater`
vendors `v3.4.47` and the match is real — the Windows-only rationale holds for a
Linux container. The comment there now names the matching package so the next
reader can re-check it without re-scanning the image.

### `v22.04/10.16.4/.trivyignore` — fix the `CVE-2026-44167` comment

It read *"fixed in oc 10.16.3, but still a false positive in the openidconnect
app"*. It is not a false positive:

- the 3.x branch of the advisory is patched in phpseclib **3.0.52**
- core `lib/composer` was bumped to 3.0.52 — clean
- but `apps/openidconnect` carries **its own** vendor copy, still at **3.0.50**,
  pulled in by `jumbojett/openid-connect-php v1.0.2` (`requires
  phpseclib/phpseclib ^3.0.7`), and the app's own autoloader resolves that copy

So the vulnerable code is the copy openidconnect actually loads. The suppression
is still the right call for now — the impact is a DoS via ASN.1 OID
amplification, reachable only through IdP-supplied X.509/JWKS material — but the
comment should not tell a future reader the finding is benign. Rewritten to state
the real reason and to name the upstream fix (an `openidconnect` 2.3.4 release
carrying phpseclib 3.0.54+).

### Not changed

No new suppressions are needed: neither image has an unsuppressed HIGH or
CRITICAL today, so CI is unaffected either way. Removing the stale 11.0.0 entry
cannot break the scan — the whole point is that it matches nothing.

Verification for both claims came from the composer inventory extracted from the
images (`installed.json` across every bundle) matched against the live GitHub
Advisory DB; the local Trivy DB is frozen at 2026-06-05 and predates the August
advisories.

Refs: OC10-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
